### PR TITLE
OpenAPI spec adjustments

### DIFF
--- a/docs/brightsky.yml
+++ b/docs/brightsky.yml
@@ -669,19 +669,25 @@ components:
       in: query
       description: DWD station ID, typically five alphanumeric characters, e.g. `P0036`. You can supply multiple station IDs separated by commas, ordered from highest to lowest priority.
       schema:
-        type: string
+        type: array
+        items:
+          type: string
     wmo_station_id:
       name: wmo_station_id
       in: query
       description: WMO station ID, typically five digits, e.g. `10315`. You can supply multiple station IDs separated by commas, ordered from highest to lowest priority.
       schema:
-        type: string
+        type: array
+        items:
+          type: string
     source_id:
       name: source_id
       in: query
       description: Bright Sky source ID, as retrieved from the `sources` endpoint, e.g. `1234`. You can supply multiple source IDs separated by commas, ordered from highest to lowest priority.
       schema:
-        type: integer
+        type: array
+        items:
+          type: integer
     max_dist:
       name: max_dist
       in: query

--- a/docs/brightsky.yml
+++ b/docs/brightsky.yml
@@ -503,7 +503,7 @@ components:
           description: Sunshine duration during previous 10 minutes
           type: number
           nullable: true
-          example: 1080
+          example: 240
         sunshine_30:
           description: Sunshine duration during previous 30 minutes
           type: number

--- a/docs/brightsky.yml
+++ b/docs/brightsky.yml
@@ -672,6 +672,7 @@ components:
         type: array
         items:
           type: string
+      explode: false
     wmo_station_id:
       name: wmo_station_id
       in: query
@@ -680,6 +681,7 @@ components:
         type: array
         items:
           type: string
+      explode: false
     source_id:
       name: source_id
       in: query
@@ -688,6 +690,7 @@ components:
         type: array
         items:
           type: integer
+      explode: false
     max_dist:
       name: max_dist
       in: query

--- a/docs/brightsky.yml
+++ b/docs/brightsky.yml
@@ -499,6 +499,11 @@ components:
           type: number
           nullable: true
           example: 40
+        sunshine_10:
+          description: Sunshine duration during previous 10 minutes
+          type: number
+          nullable: true
+          example: 1080
         sunshine_30:
           description: Sunshine duration during previous 30 minutes
           type: number


### PR DESCRIPTION
I noticed the following possible optimizations within the OpenAPI spec:
- Missing property `sunshine_10` for `SynopRecord`
- If I understand the documentation correctly, the query params `dwd_station_id`, `wmo_station_id` and `source_id` could be described as arrays